### PR TITLE
Add option to get consistent ids for identical timestamps.

### DIFF
--- a/lib/simple_uuid.rb
+++ b/lib/simple_uuid.rb
@@ -55,7 +55,7 @@ module SimpleUUID
         ]
 
         # Top 3 bytes reserved
-        if opts[:jitter] == false
+        if opts[:randomize] == false
           byte_array += [
             0 | VARIANT,
             0,

--- a/test/test_uuid.rb
+++ b/test/test_uuid.rb
@@ -64,6 +64,6 @@ class UUIDTest < Test::Unit::TestCase
     t = Time.now
 
     assert_not_equal UUID.new(t), UUID.new(t)
-    assert_equal UUID.new(t, jitter: false), UUID.new(t, jitter: false)
+    assert_equal UUID.new(t, randomize: false), UUID.new(t, randomize: false)
   end
 end


### PR DESCRIPTION
By passing :jitter => false, we do not randomize the top 3 bytes. We have a Cassandra-backed app where this is needed.

Let me know if you'd prefer another way of doing this. [pycassa](http://pycassa.github.com/pycassa/api/pycassa/util.html) has similar functionality.
