### PR TITLE
Ensure ==/to_s work correctly when raw bytes are passed in different encodings

### DIFF
--- a/lib/simple_uuid.rb
+++ b/lib/simple_uuid.rb
@@ -27,7 +27,7 @@ module SimpleUUID
       when String
         case bytes.size
         when 16 # Raw byte array
-          @bytes = bytes
+          @bytes = bytes.respond_to?(:force_encoding) ? bytes.force_encoding("ASCII-8BIT") : bytes
         when 36 # Human-readable UUID representation; inverse of #to_guid
           elements = bytes.split("-")
           raise TypeError, "Expected #{bytes.inspect} to cast to a #{self.class} (malformed UUID representation)" if elements.size != 5

--- a/test/test_uuid.rb
+++ b/test/test_uuid.rb
@@ -17,6 +17,15 @@ class UUIDTest < Test::Unit::TestCase
     assert_equal uuid, UUID.new(uuid.to_i)
     assert_equal uuid, UUID.new(uuid.to_guid)
   end
+  
+  def test_equality_with_encoding
+    return unless "".respond_to? :force_encoding
+    
+    utf8_uuid_bytes = "\xFD\x17\x1F\xA6=O\x11\xE2\x92\x13pV\x81\xBB\x05\x87".force_encoding("UTF-8")
+    binary_uuid_bytes = "\xFD\x17\x1F\xA6=O\x11\xE2\x92\x13pV\x81\xBB\x05\x87".force_encoding("ASCII-8BIT")
+    
+    assert_equal UUID.new(utf8_uuid_bytes), UUID.new(binary_uuid_bytes)
+  end
 
   def test_uuid_error
     assert_raises(TypeError) do


### PR DESCRIPTION
ensure they are forced to ASCII-8BIT(binary) encoding so ==/to_s doesn't return strings that are encoded differently

I've made allowances for rubies that don't support the force_encoding method (1.8)
## 

Initially the added test failed with:

```
   test_equality_with_encoding(UUIDTest) 
   <<UUID#70359646839260 time: 2012-12-03 13:47:33 +0000, usecs: 239799 jitter: 9729388734179185554>> expected but was
   <<UUID#70359646839060 time: 2012-12-03 13:47:33 +0000, usecs: 239799 jitter: 9729388734179185554>>.
```
