### PR TITLE
Enable user provided non-randomized salt for clock and node fields instead of jitter

### DIFF
--- a/lib/simple_uuid.rb
+++ b/lib/simple_uuid.rb
@@ -56,11 +56,19 @@ module SimpleUUID
 
         # Top 3 bytes reserved
         if opts[:randomize] == false
-          byte_array += [
-            0 | VARIANT,
-            0,
-            0
-          ]
+          byte_array += if !opts[:salt].nil?
+            clock_h, clock_l, node_h, node_l =
+              opts[:salt].to_s.unpack("CCnN")
+
+            clock = [
+              clock_h | VARIANT,
+              clock_l
+            ].pack("n").unpack("n").first
+
+            [ clock, node_h, node_l ]
+          else
+            [ 0 | VARIANT, 0, 0 ]
+          end
         else
           byte_array += [
             rand(2**13) | VARIANT,

--- a/test/test_uuid.rb
+++ b/test/test_uuid.rb
@@ -1,5 +1,7 @@
 require 'test/unit'
+require 'digest/md5'
 require 'simple_uuid'
+
 include SimpleUUID
 
 class UUIDTest < Test::Unit::TestCase
@@ -25,6 +27,20 @@ class UUIDTest < Test::Unit::TestCase
     binary_uuid_bytes = "\xFD\x17\x1F\xA6=O\x11\xE2\x92\x13pV\x81\xBB\x05\x87".force_encoding("ASCII-8BIT")
     
     assert_equal UUID.new(utf8_uuid_bytes), UUID.new(binary_uuid_bytes)
+  end
+
+  def test_salt
+    tnow = Time.now
+    salt =  Digest::MD5.new.update("some salt")
+    tthen = Time.now
+
+    uuid1 = UUID.new(tnow, :randomize => false, :salt => salt.digest)
+    uuid2 = UUID.new(tthen, :randomize => false, :salt => salt.digest)
+
+    assert_equal uuid1.to_time, tnow
+    assert_equal uuid2.to_time, tthen
+    assert_equal uuid1.bytes[8..-1], uuid2.bytes[8..-1]
+    assert uuid2 > uuid1
   end
 
   def test_uuid_error


### PR DESCRIPTION
This change set makes it possible to integrate identity in the UUID based on time plus computed hash of some value.
It is recommended that the passed salt is genereated by a quality hash function like SHA1 or MD5. Otherwise the risk for collision will increase.
This implementation is not RFC4122 compliant.
