### PR TITLE
SecureRandom

### DIFF
--- a/lib/simple_uuid.rb
+++ b/lib/simple_uuid.rb
@@ -1,3 +1,5 @@
+require 'securerandom'
+
 class Time
   def self.stamp
     Time.now.stamp
@@ -71,9 +73,9 @@ module SimpleUUID
           end
         else
           byte_array += [
-            rand(2**13) | VARIANT,
-            rand(2**16),
-            rand(2**32)
+            SecureRandom.random_number(2**13) | VARIANT,
+            SecureRandom.random_number(2**16),
+            SecureRandom.random_number(2**32)
           ]
         end
 


### PR DESCRIPTION
`Random::rand` is a PRNG based on the Mersenne Twister (MT) algorithm. MT generates results that _look_ very random, but it is relatively easy to [clone the internal state of the generator](http://crypto.di.uoa.gr/CRYPTO.SEC/Randomness_Attacks_files/paper.pdf). This PR switches from `Random::rand` to `SecureRandom::random_number`, which backends to OpenSSL. 

I know `SimpleUUID` doesn't make any promises about the quality of its randomness. Also, I know that type 4 UUIDs are generally used when randomness is desirable. That being said, it seems like better randomness is preferable. We are using this gem and are in a situation where we appreciate the fact that type 1 UUIDs give insights into time (unlike type 4), but would still like some randomness if possible.
