### PR TITLE
Speed up == and cache to_guid

### DIFF
--- a/test/test_uuid.rb
+++ b/test/test_uuid.rb
@@ -27,6 +27,11 @@ class UUIDTest < Test::Unit::TestCase
     binary_uuid_bytes = "\xFD\x17\x1F\xA6=O\x11\xE2\x92\x13pV\x81\xBB\x05\x87".force_encoding("ASCII-8BIT")
 
     assert_equal UUID.new(utf8_uuid_bytes), UUID.new(binary_uuid_bytes)
+
+    hash = {}
+    hash[UUID.new(utf8_uuid_bytes)] = 'watch'
+    hash[UUID.new(binary_uuid_bytes)] = 'out'
+    assert_equal 1, hash.size
   end
 
   def test_salt
@@ -117,5 +122,13 @@ class UUIDTest < Test::Unit::TestCase
     # collect freezes the key values as you iterate
     objectified = hash.collect {|k,v| UUID.new(k) }
     assert_equal uuid, objectified[0]
+  end
+
+  def test_to_guid_caching
+    uuid = UUID.new
+    guid = uuid.to_guid
+    guid.upcase!
+    # show we dup the cached guid
+    assert_equal guid.downcase, uuid.to_guid
   end
 end


### PR DESCRIPTION
I had to put back the force_encoding call since == now just
compares the bytes again, and strings with incompatible encodings
always compare false. This also means eql? has been comparing strings
with different encodings incorrectly. Added a test for that.